### PR TITLE
Removed the need for the collections module

### DIFF
--- a/rpc_deployment/inventory/dynamic_inventory.py
+++ b/rpc_deployment/inventory/dynamic_inventory.py
@@ -17,7 +17,6 @@
 
 import argparse
 import datetime
-import collections
 import hashlib
 import json
 import os
@@ -696,7 +695,7 @@ def _merge_dict(base_items, new_items):
     :return dictionary:
     """
     for key, value in new_items.iteritems():
-        if isinstance(value, collections.Mapping):
+        if isinstance(value, dict):
             base_merge = _merge_dict(base_items.get(key, {}), value)
             base_items[key] = base_merge
         else:
@@ -717,7 +716,7 @@ def _extra_config(user_defined_config, base_dir):
                 with open(file_path, 'rb') as f:
                     _merge_dict(
                         user_defined_config,
-                        yaml.safe_load(f.read())
+                        yaml.safe_load(f.read()) or {}
                     )
 
 


### PR DESCRIPTION
The reason I was using collections.mapping was in case we wanted to
support other types of maps other then a dictionary. Seeing as the
name of the method is now merge_dicts and the doc string specifies
that dicts are expected, I removed the need for the collections
module.

  -if isinstance(value, collections.Mapping):
  +if isinstance(value, dict):

Also added an 'or {}' to call to _merge_dict from _extra_config.
This way if yaml.safe_load returns a None, or other false value an
empty dict will be passed to the _merge_dict method as expected.

  -yaml.safe_load(f.read())
  +yaml.safe_load(f.read()) or {}

I.e if someone just dumps/touches an empty file into the conf.d it
wont crash.
